### PR TITLE
RB 73 Reset password - backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.8.2",
         "morgan": "^1.10.0",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "nodemailer": "^6.9.16"
       },
       "devDependencies": {
         "eslint": "^9.14.0",
@@ -1902,6 +1903,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.16.tgz",
+      "integrity": "sha512-psAuZdTIRN08HKVd/E8ObdV6NO7NTBY3KsC30F7M4H1OnmLCUNaS56FpYxyb26zWLSyYF9Ozch9KYHhHegsiOQ==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -4089,6 +4098,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "nodemailer": {
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.16.tgz",
+      "integrity": "sha512-psAuZdTIRN08HKVd/E8ObdV6NO7NTBY3KsC30F7M4H1OnmLCUNaS56FpYxyb26zWLSyYF9Ozch9KYHhHegsiOQ=="
     },
     "nodemon": {
       "version": "2.0.22",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.8.2",
     "morgan": "^1.10.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "nodemailer": "^6.9.16"
   },
   "devDependencies": {
     "eslint": "^9.14.0",

--- a/src/controllers/passwordRecoveryController.js
+++ b/src/controllers/passwordRecoveryController.js
@@ -1,0 +1,48 @@
+const { BadRequestError } = require('../errors');
+const User = require('../models/User');
+const sendEmail = require('../utils/sendEmail');
+const jwt = require('jsonwebtoken');
+const { StatusCodes } = require('http-status-codes');
+
+const requestPasswordReset = async (req, res, next) => {
+  try {
+    const { email } = req.body;
+    if (!email) {
+      throw new BadRequestError('Please provide an email');
+    }
+
+    const user = await User.findOne({ email });
+    if (!user) {console.log('User not found for email:', email);
+      throw new BadRequestError('User with this email does not exist');
+    }
+
+    const resetToken = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
+      expiresIn: '1h',
+    });
+
+    const resetLink = `${process.env.FRONTEND_URL}/password/reset?token=${resetToken}`;
+    if (!process.env.FRONTEND_URL) {
+      throw new BadRequestError('FRONTEND_URL is not available in .env');
+    }
+
+    const resetMessage = `
+            <h3>Password Reset Request</h3>
+            <p>You are receiving this email because you (or someone else) have requested the reset of a password.</p>
+            <p>If you did not request this, please ignore this email.</p>
+            <p>Please click the link below to reset your password.</p>
+            <p>This link is valid for 1 hour:</p>
+            <a href="${resetLink}">Reset Password</a>
+          `;
+
+    await sendEmail(user.email, 'Password Reset Request', resetMessage);
+
+    res.status(StatusCodes.OK).json({ msg: 'Reset link sent to email' });
+  } catch (error) {
+    console.error('Error sending reset email:', error.message);
+    next(error);
+  }
+};
+
+module.exports = {
+  requestPasswordReset,
+};

--- a/src/controllers/passwordRecoveryController.js
+++ b/src/controllers/passwordRecoveryController.js
@@ -26,7 +26,7 @@ const requestPasswordReset = async (req, res, next) => {
     user.resetTokenExpires = Date.now() + 60 * 60 * 1000;
     await user.save();
 
-    const resetLink = `${process.env.FRONTEND_URL}/password/reset?token=${resetToken}`;
+    const resetLink = `${process.env.FRONTEND_URL}/password/edit?token=${resetToken}`;
     if (!process.env.FRONTEND_URL) {
       throw new BadRequestError('Frontend URL is not available in .env');
     }

--- a/src/controllers/passwordRecoveryController.js
+++ b/src/controllers/passwordRecoveryController.js
@@ -20,12 +20,6 @@ const requestPasswordReset = async (req, res, next) => {
       expiresIn: '1h',
     });
 
-    console.log(resetToken);
-
-    user.resetToken = resetToken;
-    user.resetTokenExpires = Date.now() + 60 * 60 * 1000;
-    await user.save();
-
     const resetLink = `${process.env.FRONTEND_URL}/password/edit?token=${resetToken}`;
     if (!process.env.FRONTEND_URL) {
       throw new BadRequestError('Frontend URL is not available in .env');
@@ -41,10 +35,11 @@ const requestPasswordReset = async (req, res, next) => {
           `;
 
     await sendEmail(user.email, 'Password Reset Request', resetMessage);
+    user.resetToken = resetToken;
+    user.resetTokenExpires = Date.now() + 60 * 60 * 1000;
+    await user.save();
 
-    res
-       .status(StatusCodes.OK)
-       .json({ msg: 'Reset link sent to email' });
+    res.status(StatusCodes.OK).json({ msg: 'Reset link sent to email' });
   } catch (error) {
     console.error('Error sending reset email:', error.message);
     next(error);

--- a/src/controllers/passwordRecoveryController.js
+++ b/src/controllers/passwordRecoveryController.js
@@ -8,12 +8,12 @@ const requestPasswordReset = async (req, res, next) => {
   try {
     const { email } = req.body;
     if (!email) {
-      throw new BadRequestError('Please provide an email');
+      throw new BadRequestError('Please provide an email.');
     }
 
     const user = await User.findOne({ email });
-    if (!user) {console.log('User not found for email:', email);
-      throw new BadRequestError('User with this email does not exist');
+    if (!user) {
+      throw new BadRequestError('Invalid Credentials.');
     }
 
     const resetToken = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
@@ -22,7 +22,7 @@ const requestPasswordReset = async (req, res, next) => {
 
     const resetLink = `${process.env.FRONTEND_URL}/password/reset?token=${resetToken}`;
     if (!process.env.FRONTEND_URL) {
-      throw new BadRequestError('FRONTEND_URL is not available in .env');
+      throw new BadRequestError('Frontend URL is not available in .env');
     }
 
     const resetMessage = `

--- a/src/controllers/passwordRecoveryController.js
+++ b/src/controllers/passwordRecoveryController.js
@@ -51,7 +51,7 @@ const requestPasswordReset = async (req, res, next) => {
   }
 };
 
-const resetPassword = async (req, res) => {
+const resetPassword = async (req, res, next) => {
   try {
     const { token, newPassword } = req.body;
 

--- a/src/errors/email-error.js
+++ b/src/errors/email-error.js
@@ -1,0 +1,8 @@
+class EmailError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'EmailError';
+  }
+};
+
+module.exports = EmailError;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -33,6 +33,8 @@ const UserSchema = new mongoose.Schema({
     type: String,
     maxlength: 100,
   },
+  resetToken: String,
+  resetTokenExpires: Date,
 });
 
 UserSchema.pre('save', async function () {

--- a/src/routes/userRouter.js
+++ b/src/routes/userRouter.js
@@ -1,10 +1,14 @@
 const express = require('express');
 const router = express.Router();
 const { register, login, logout, updateUser } = require('../controllers/userController.js');
+const { requestPasswordReset } = require('../controllers/passwordRecoveryController.js');
 
 router.post('/register', register);
 router.post('/login', login);
 router.post('/logout', logout);
 router.patch('/update', updateUser);
+
+//password recovery
+router.post('/forgot-password', requestPasswordReset);
 
 module.exports = router;

--- a/src/routes/userRouter.js
+++ b/src/routes/userRouter.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { register, login, logout, updateUser } = require('../controllers/userController.js');
-const { requestPasswordReset } = require('../controllers/passwordRecoveryController.js');
+const { requestPasswordReset, resetPassword } = require('../controllers/passwordRecoveryController.js');
 
 router.post('/register', register);
 router.post('/login', login);
@@ -10,5 +10,6 @@ router.patch('/update', updateUser);
 
 //password recovery
 router.post('/forgot-password', requestPasswordReset);
+router.post('/password-reset', resetPassword);
 
 module.exports = router;

--- a/src/utils/sendEmail.js
+++ b/src/utils/sendEmail.js
@@ -7,11 +7,13 @@ const transporter = nodemailer.createTransport({
     user: process.env.GMAIL_USER,
     pass: process.env.GMAIL_PASS,
   },
+//   logger: true, 
+//   debug: true,  
 });
 
 const sendEmail = async (to, subject, html) => {
   const mailOptions = {
-    from: `Shop Re:Books <${process.env.GMAIL_USER}>`,
+    from: `ReBooks <${process.env.GMAIL_USER}>`,
     to,
     subject,
     html, 

--- a/src/utils/sendEmail.js
+++ b/src/utils/sendEmail.js
@@ -1,0 +1,29 @@
+const nodemailer = require('nodemailer');
+const EmailError = require('../errors/email-error');
+
+const transporter = nodemailer.createTransport({
+  service: 'Gmail',
+  auth: {
+    user: process.env.GMAIL_USER,
+    pass: process.env.GMAIL_PASS,
+  },
+});
+
+const sendEmail = async (to, subject, html) => {
+  const mailOptions = {
+    from: `Shop Re:Books <${process.env.GMAIL_USER}>`,
+    to,
+    subject,
+    html, 
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log('Email sent successfully');
+  } catch (error) {
+    console.error('Error sending email:', error);
+    throw new EmailError('Error sending email');
+  }
+};
+
+module.exports = sendEmail;


### PR DESCRIPTION
## Description
Added functionality to allow users to reset their password in case they forget it.
## Changes

## Related issues

## Screenshots
The user provides their email address, and a password reset link is sent to it. For testing purposes, the token is temporarily logged in the console but will be removed later.
![send-link](https://github.com/user-attachments/assets/f4acf95c-33e7-4633-8325-a0bf486b4a72)

If the user does not provide an email address or if no matching user is found, appropriate error messages are displayed.
![forgot-password-error](https://github.com/user-attachments/assets/63baf23b-0ea0-4775-84a3-7fee0c9f709f)

![forgot-password-error2](https://github.com/user-attachments/assets/f235e77d-2dd9-4dfe-bd94-cef5d02f34bd)

To set a new password, a token and the new password are required.
![new-password](https://github.com/user-attachments/assets/48af6ae5-0f7d-4c49-9659-00676d281231)

If the token is not provided or has expired, error messages are displayed.
![reset-password-error](https://github.com/user-attachments/assets/2b030797-60d5-4bf9-af97-a8623e0cf079)
![reset-password-error2](https://github.com/user-attachments/assets/e2cfd0bc-a784-4bdc-9000-41626e7f3992)

After a new password is set, logging in with the old password is no longer possible.
![error-login-with-old-password](https://github.com/user-attachments/assets/72560aab-fd2d-4095-b353-0b28e1140ca4)

The user can log in only with the new password.
![new-pass-login](https://github.com/user-attachments/assets/59f381b0-a07f-45bd-8535-e4ac14d80a4e)
